### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Usage Example
     display = GC9A01(display_bus, width=240, height=240)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(240, 240, 1)

--- a/examples/gc9a01_simpletest.py
+++ b/examples/gc9a01_simpletest.py
@@ -22,7 +22,7 @@ display_bus = displayio.FourWire(spi, command=dc, chip_select=cs, reset=reset)
 display = GC9A01(display_bus, width=240, height=240)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(240, 240, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a GC9A01 display to test with

Thanks